### PR TITLE
Fixes #3

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -17,7 +17,7 @@ require("prototypes.airbornePlanes") -- Make airborne plane clones first
 -- WARNING
 -- max_health must be the max_health of the original plane DIVIDED BY 2
 function ExtendGroundedAircraft(name, rotation_speed, braking_power, max_health, weight, collision_box)
-    data.raw.car[name].collision_mask = {"player-layer", "train-layer", "consider-tile-transitions"}
+    data.raw.car[name].collision_mask = {"player-layer", "train-layer"}
 
     if settings.startup["aircraft-realism-turn-radius"].value then
         data.raw.car[name].tank_driving = false

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -17,7 +17,7 @@ require("prototypes.airbornePlanes") -- Make airborne plane clones first
 -- WARNING
 -- max_health must be the max_health of the original plane DIVIDED BY 2
 function ExtendGroundedAircraft(name, rotation_speed, braking_power, max_health, weight, collision_box)
-    data.raw.car[name].collision_mask = {"player-layer", "train-layer"}
+    data.raw.car[name].collision_mask = {"player-layer", "train-layer", "consider-tile-transitions", "water-tile"}
 
     if settings.startup["aircraft-realism-turn-radius"].value then
         data.raw.car[name].tank_driving = false

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -17,7 +17,7 @@ require("prototypes.airbornePlanes") -- Make airborne plane clones first
 -- WARNING
 -- max_health must be the max_health of the original plane DIVIDED BY 2
 function ExtendGroundedAircraft(name, rotation_speed, braking_power, max_health, weight, collision_box)
-    data.raw.car[name].collision_mask = {"player-layer", "train-layer", "consider-tile-transitions", "water-tile"}
+    data.raw.car[name].collision_mask = {"player-layer", "train-layer", "consider-tile-transitions"}
 
     if settings.startup["aircraft-realism-turn-radius"].value then
         data.raw.car[name].tank_driving = false

--- a/logic/planeCollisions.lua
+++ b/logic/planeCollisions.lua
@@ -12,8 +12,11 @@ local function obstacleCollision(settings, surface, player, plane)
         end
     end
     -- Destroy the plane upon landing in water
-    local tile = surface.get_tile(plane.position).name
-    if tile == "water" or tile == "water-shallow" or tile == "water-mud"or tile == "water-green" or tile == "deepwater" or tile == "deepwater-green" then
+    local tile = surface.get_tile(plane.position)
+	if tile == nil or not tile.valid then
+		return;
+	end
+    if tile.name == "water" or tile.name == "water-shallow" or tile.name == "water-mud"or tile.name == "water-green" or tile.name == "deepwater" or tile.name == "deepwater-green" then
         if plane.speed == 0 then  --Player + passenger dies too since they will just be stuck anyways
             planeUtils.killDriverAndPassenger(plane, player)
 

--- a/logic/planeManager.lua
+++ b/logic/planeManager.lua
@@ -38,7 +38,7 @@ local function checkPlanes(e, player, game, defines, settings)
         -- Collision gets checked every tick for accuracy
         if planeRunway.validateRunwayTile(settings, player.surface, player.vehicle) then -- Returns false if the plane did not pass and was destroyed
             -- Test for obstacle collision (water, cliff)
-            planeCollisions.obstacleCollision(settings, game.surfaces[1], player, player.vehicle)
+            planeCollisions.obstacleCollision(settings, player.surface, player, player.vehicle)
         end
 
     elseif quarterSecond and planeUtility.isAirbornePlane(player.vehicle.name) then

--- a/logic/planeRunway.lua
+++ b/logic/planeRunway.lua
@@ -6,7 +6,7 @@ local function validateRunwayTile(settings, surface, plane)
     -- player.print(tile.name .. " | " ..tile.prototype.vehicle_friction_modifier) --For debug testing different surfaces
 
     -- If strict runways are set, limit the plane's speed when not on runway material, dealing damage if landing on it
-    if settings.global["aircraft-realism-strict-runway-checking"].value then
+    if settings.global["aircraft-realism-strict-runway-checking"].value and tile ~= nil and tile.valid then
 
         -- Cap the max speed to the max taxi speed when not on a runway
         if tile.prototype.vehicle_friction_modifier > settings.global["aircraft-realism-strict-runway-checking-maximum-tile-vehicle-friction"].value then


### PR DESCRIPTION
This push fixes the get_tile error, which seems to be caused because the obstacleCollision function is being passed game.surfaces[1] rather than player.surface.
I also added validity checks to the tile that is returned.
Furthermore, I added water to the collision masks of the grounded planes.