### PR TITLE
Fix taking damage when flying over an acid puddles.

### DIFF
--- a/aircraftMaker.lua
+++ b/aircraftMaker.lua
@@ -53,9 +53,18 @@ local function setupHealth(plane, airborne)
     end
 end
 
-local function setupHandling(plane)
+local function setupHandling(plane, airborne)
     if settings.startup["aircraft-realism-turn-radius"].value then
         plane.tank_driving = false
+    end
+
+    if airborne then
+        -- Override default for "car" type avoids damage/stickers from moving over acid puddles.
+        plane.trigger_target_mask = { "common" }
+    else
+        -- Ensure vulnerability to acid pools while on the ground.
+        -- This is the default for "car" type, but could be overridden in other mods.
+        plane.trigger_target_mask = { "common", "ground-unit" }
     end
 end
 
@@ -108,7 +117,7 @@ local function makeGrounded(config)
         data.isSeaplane = config.isSeaplane
     end)
     setupHealth(plane, false)
-    setupHandling(plane)
+    setupHandling(plane, false)
     setupFuelConsumption(plane, false)
 end
 
@@ -204,7 +213,7 @@ local function makeAirborne(config)
 
     plane.collision_mask = {}
     setupHealth(plane, true)
-    setupHandling(plane)
+    setupHandling(plane, true)
     setupFuelConsumption(plane, true)
     data:extend{plane}
 


### PR DESCRIPTION
Clear/set "ground-unit" trigger_target_mask in makeAirborne/makeGrounded. 

As far as I can tell for vanilla, this only affects ground acid ("fire") pool interaction.  Melee attacks and direct hits from spitters are unaffected.  

Related to #19, this doesn't fully fix the problem.  However, flying through crowds is quite a lot easier if not having to dodge puddles.

Background:

I submitted a related PR to Aircraft mod Stifling-Bossness/Aircraft/pull/61.  This PR does not strictly depend on that one, but is the reason for enforcing the `"car"` prototype's default `trigger_target_mask`.  See that PR for more background about `trigger_target_mask` in the factorio API.